### PR TITLE
Allow user to specify download directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ npm install
 
 ## Running
 
-Open ```config.js``` and substitute in your Spotify client id and client secret, as well as your Youtube API Key. After this you can then run ```node src/index.js spotify_account_name spotify_playlist_id```
+Open ```config.js``` and substitute in your Spotify client id and client secret, as well as your Youtube API Key. 
+
+You can specify the directory you wish to download the playlist to in ```config.js```. For example, ```directory : '~/Music'```. If the directory is not specified, spodl will download the playlist to the spodl directory.
+
+After this you can then run ```node src/index.js spotify_account_name spotify_playlist_id```
 
 For example:
 

--- a/config.js
+++ b/config.js
@@ -5,5 +5,6 @@ module.exports = {
   },
   youtube : {
     apikey : ''
-  }
+  },
+  directory : ''
 };

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const util = require('util');
 const exec = require('child_process').exec;
 let playlistName = '';
+let dir = config.directory;
 
 const youTube = new YouTube();
 youTube.setKey(config.youtube.apikey);
@@ -64,8 +65,8 @@ const yt = (searchTerm) => youTube.search(searchTerm, 1, ytCb);
 
 //Downloading
 const dl = (url) => {
-  const cmd = process.argv[4] === 'video' ? 'youtube-dl -o "' + playlistName + '/%(title)s.%(ext)s"'  :
-  'youtube-dl -o "' + playlistName + '/%(title)s.%(ext)s" --extract-audio --audio-format mp3 ';
+  const cmd = process.argv[4] === 'video' ? 'youtube-dl -o "' + dir + playlistName + '/%(title)s.%(ext)s"'  :
+  'youtube-dl -o "' + dir + playlistName + '/%(title)s.%(ext)s" --extract-audio --audio-format mp3 ';
   exec(cmd+url, dlCb);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const fs = require('fs');
 const util = require('util');
 const exec = require('child_process').exec;
 let playlistName = '';
-let dir = config.directory;
+const dir = config.directory;
 
 const youTube = new YouTube();
 youTube.setKey(config.youtube.apikey);


### PR DESCRIPTION
This change allows the user to specify the download directory in the config file. For example, we can set the download directory to ~/Music/.

If a download directory is not specified, the playlist will default to downloading the playlist to the spodl directory.